### PR TITLE
CI: stop pinning moby/buildkit:master in publish (regressed /proc/acpi)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver-opts: |
-            image=moby/buildkit:master
             network=host
           buildkitd-config-inline: |
             [registry."${{ secrets.REHOSTING_ARC_REGISTRY }}"]
@@ -131,7 +130,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver-opts: |
-            image=moby/buildkit:master
             network=host
           buildkitd-config-inline: |
             [registry."${{ secrets.REHOSTING_ARC_REGISTRY }}"]


### PR DESCRIPTION
## Problem

The publish run on `main` after #9 merged **failed** ([run](https://github.com/rehosting/embedded-toolchains/actions/runs/27708570454)):

```
#11 runc run failed: unable to start container process: error during container init:
can't mask dir "/proc/acpi": mount src=tmpfs, dst=/proc/acpi, flags=MS_RDONLY,
data=nr_blocks=1,nr_inodes=1: invalid argument
```

It fails the first `RUN` of every build, so nothing publishes. This is **not** related to the #9 Dockerfile change — `publish.yml`'s two `setup-buildx-action` steps (jobs `build` and `build-arch`) pin the **floating** `moby/buildkit:master`, and a recent master regressed on the `rehosting-arc` runners (runc/kernel interaction masking `/proc/acpi`). publish last succeeded **2026-04-15** on an older master and has been latently broken since.

## Fix

Drop the `image=moby/buildkit:master` override from both buildx setups so buildx uses its **default pinned-stable** buildkit (`network=host` and the insecure-registry config are kept). This is the same fix already merged for the PR check in `build.yml` (#9), where it took the build from failing to green in ~4 min.

## Verification

The identical change on `build.yml` (PR check, same runners, same proxy/cache setup) now builds the `final` target successfully on `rehosting-arc`. This PR's own PR-check run exercises that fixed `build.yml`; the publish path will use stable buildkit on the next push to `main`.